### PR TITLE
Fix redundant lines and arranged the header to properly execute the s…

### DIFF
--- a/esp32_light_monitor/esp32_light_monitor_fixed/esp32_light_monitor_fixed.ino
+++ b/esp32_light_monitor/esp32_light_monitor_fixed/esp32_light_monitor_fixed.ino
@@ -18,12 +18,12 @@
 #include <BH1750.h>
 
 // ─── WiFi Configuration ───────────────────────────────────────────────────────
-const char* ssid     = "Wifi name
-const char* password = "Your wifi password";
+const char* ssid     = "";
+const char* password = "";
 
 // ─── Server Configuration ─────────────────────────────────────────────────────
-// TODO: Replace with your actual server IP or domain
-const char* serverName = "serverlink"
+// TODO: Replace with your current ngrok URL each session
+const char* serverName = "insert the link here";  // e.g. "https://abcd1234.ngrok.io/api/receive_data.php"
 
 // ─── Device Configuration ─────────────────────────────────────────────────────
 const char* deviceId = "ESP32_001";
@@ -302,7 +302,6 @@ bool sendDataToServer(float lux, String level, String device_id) {
   WiFiClientSecure client;
   client.setInsecure();  // skip SSL cert verification
   HTTPClient http;
-  http.addHeader("ngrok-skip-browser-warning", "true");
 
   Serial.print("Sending to: ");
   Serial.println(serverName);
@@ -312,6 +311,7 @@ bool sendDataToServer(float lux, String level, String device_id) {
     return false;
   }
 
+  http.addHeader("ngrok-skip-browser-warning", "true");
   http.addHeader("Content-Type", "application/x-www-form-urlencoded");
   http.addHeader("User-Agent", "ESP32-LightMonitor/1.0");
   http.setTimeout(10000);


### PR DESCRIPTION
## Summary
Set up and tested the full IoT pipeline locally using XAMPP and ngrok 
as a temporary public tunnel. This PR covers everything from initial 
sensor testing to a fully working live dashboard receiving real sensor 
data from the ESP32 + BH1750.

## Changes Made

### Arduino (esp32_light_monitor_fixed.ino)
- Fixed duplicate handleWiFiDisconnection() function definition
- Fixed duplicated logic blocks inside performReading()
- Fixed missing closing brace in sendDataToServer()
- Removed unused ArduinoJson import
- Removed infinite while(true) loop in sensor initialization
- Added WiFiClientSecure with setInsecure() for HTTPS support
- Fixed ngrok-skip-browser-warning header placement - moved to 
  after http.begin() to prevent connection errors
- Fixed missing semicolon on serverName declaration
- Fixed STATUS_LED pin definition conflict
- Updated serverName to point to ngrok tunnel + correct path
  (https://[ngrok-url]/I-O-T/api/insert.php)
- Switched WiFi from 5GHz (Jacamos Wifi-5G) to 2.4GHz — 
  ESP32 does not support 5GHz networks

### PHP (api/get_data.php)
- Full rewrite to fix broken SQL query structure
- Fixed ORDER BY being appended after prepare() call
- Added proper queries for total readings, average lux,
  chart data, recent data, and level distribution

### PHP (api/config.php)
- Fixed classifyLightLevel() returning capitalized strings
  (Low, Moderate, High) - changed to lowercase to match
  database ENUM values
- Fixed database port from 3307 to 3306
- Set timezone to Asia/Manila

### PHP/HTML (index.php)
- Fixed row.lux.toFixed() TypeError by wrapping with parseFloat()
- Fixed level color classes using wrong capitalization
- Fixed system online/offline detection due to UTC vs PST mismatch
- Changed auto-refresh interval from 30 seconds to 5 seconds
  to match ESP32 reading interval

### Database
- Created light_monitoring database on XAMPP
- Ran database_setup.sql to create sensor_data table
- Created logs/ folder to fix PHP 500 error on startup

## Setup Requirements
- XAMPP running Apache + MySQL on port 3306
- ngrok tunnel running: ngrok.exe http 80
- ESP32 connected to 2.4GHz WiFi
- ngrok URL updated in serverName on every new session
  (free tier generates new URL each time)

## Testing
- BH1750 sensor confirmed detecting light changes
- ESP32 WiFi connected and sending HTTP 200 responses
- Dashboard showing live data: current lux, pollution level,
  total readings, average lux, trend chart, recent data table
- Auto-refresh every 5 seconds confirmed working

## Notes
- ngrok URL is temporary and changes every session on free tier
- serverName in .ino must be updated when ngrok is restarted
- System online/offline threshold set to 500 minutes as a 
  temporary fix for timezone mismatch - proper UTC handling 
  should be implemented before production

## Closes Issues
Closes #1 - Sensor can't connect to WLAN
Closes #2 - HTTP Error
Closes #3 - Live Page not properly fetch the data sent